### PR TITLE
Bugfix: TextConverter: Do not duplicate the content of text files.

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/TextConverter.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/TextConverter.java
@@ -62,8 +62,6 @@ public class TextConverter implements Converter {
         String srcString = Util.toString(src, StandardCharsets.ISO_8859_1);
         String destString = profile.convert(srcString);
 
-        dest.write(destString.getBytes());
-
         ByteArrayInputStream bais = new ByteArrayInputStream(destString.getBytes(StandardCharsets.ISO_8859_1));
         Util.copy(bais, dest);
     }

--- a/src/test/java/org/apache/tomcat/jakartaee/TextConverterTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/TextConverterTest.java
@@ -1,0 +1,34 @@
+package org.apache.tomcat.jakartaee;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public class TextConverterTest {
+
+	private static final String INPUT = "javax.servlet.http.HttpServletRequest";
+	private static final String OUTPUT = "jakarta.servlet.http.HttpServletRequest";
+
+	@Test
+	public void testConvert() throws IOException {
+
+		// prepare
+		TextConverter converter = new TextConverter();
+		ByteArrayInputStream in = new ByteArrayInputStream(INPUT.getBytes(StandardCharsets.ISO_8859_1));
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		EESpecProfile profile = EESpecProfile.EE;
+
+		// test
+		converter.convert(in, out, profile);
+
+		// assert
+		String result = new String(out.toByteArray(), StandardCharsets.ISO_8859_1);
+		assertEquals(OUTPUT, result);
+
+	}
+
+}


### PR DESCRIPTION
Due to a bug in the convert method, TextConverter has duplicated the content of all the files it has processed. As a result, the web application deployment descriptor file web.xml has been corrupted and Tomcat has thrown an exception when trying to parse it.