### PR TITLE
Bugfix: EESpecProfile for Tomcat: Exclude Java packages not migrated to Jakarta

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/EESpecProfile.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/EESpecProfile.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
  */
 public enum EESpecProfile {
 
-    TOMCAT("javax([/\\.](annotation|ejb|el|mail|persistence|security[/\\.]auth[/\\.]message|servlet|transaction|websocket))"),
+    TOMCAT("javax([/\\.](annotation(?![/\\.]processing)|ejb|el|mail|persistence|security[/\\.]auth[/\\.]message|servlet|transaction(?![/\\.]xa)|websocket))"),
 
     EE("javax([/\\.](activation|annotation|decorator|ejb|el|enterprise|json|interceptor|inject|mail|persistence|"
                 + "security[/\\.]auth[/\\.]message|servlet|transaction|validation|websocket|ws[/\\.]rs|"

--- a/src/test/java/org/apache/tomcat/jakartaee/EESpecProfileTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/EESpecProfileTest.java
@@ -1,0 +1,44 @@
+package org.apache.tomcat.jakartaee;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class EESpecProfileTest {
+
+	@Test
+	public void testConvert_withTomcatProfile() {
+
+		// prepare
+		EESpecProfile profile = EESpecProfile.TOMCAT;
+
+		// test: classes moved to jakarta.* packages
+		testConverted("javax.annotation.PostConstruct", profile);
+		testConverted("javax.ejb.EJB", profile);
+		testConverted("javax.el.ELContext", profile);
+		testConverted("javax.mail.Session", profile);
+		testConverted("javax.persistence.PersistenceContext", profile);
+		testConverted("javax.security.auth.message.MessageInfo", profile);
+		testConverted("javax.servlet.ServletContext", profile);
+		testConverted("javax.transaction.Transaction", profile);
+		testConverted("javax.websocket.Endpoint", profile);
+
+		// test: classes not moved to jakarta.* packages
+		// (these classes are still part of the JDK - even in Java 11 and greater)
+		testNotConverted("javax.annotation.processing.Processor", profile);
+		testNotConverted("javax.transaction.xa.XAResource", profile);
+
+	}
+
+	private void testConverted(String className, EESpecProfile profile) {
+		String result = profile.convert(className);
+		String expectedResult = className.replace("javax.", "jakarta.");
+		assertEquals(expectedResult, result);
+	}
+
+	private void testNotConverted(String className, EESpecProfile profile) {
+		String result = profile.convert(className);
+		assertEquals(className, result);
+	}
+
+}


### PR DESCRIPTION
The following Java packages have not been migrated to the new Jakarta workspace:

- javax.annotation.processing (part of module [java.compiler](https://docs.oracle.com/en/java/javase/14/docs/api/java.compiler/module-summary.html))
- javax.transation.xa (module [java.transaction.xa](https://docs.oracle.com/en/java/javase/14/docs/api/java.transaction.xa/module-summary.html))

Classes from these packages are still part of the JDK - even in Java 11 and greater. They have not been migrated to jakarta.* packages.

The current pattern for EESpecProfile.TOMCAT does not take this into account. As a result, the migration tool renames classes from these packages. Java classes with dependencies on these packages then cause NoClassDefFoundErrors.

Even Tomcat 10.0.0-M4 makes use of these Java packages (in their original javax.* namespace).

ecj-4.15.jar has dependencies on ...

- javax.annotation.processing.Filer
- javax.annotation.processing.FilerException
- javax.annotation.processing.Messager
- javax.annotation.processing.ProcessingEnvironment
- javax.annotation.processing.Processor
- javax.annotation.processing.RoundEnvironment

tomcat-dbcp.jar has dependencies on ...

- javax.transaction.xa.XAException
- javax.transaction.xa.XAResource
- javax.transaction.xa.Xid

This pull request fixes this issue by adding two "negative lookahead" sequences into the regex pattern for the Tomcat migration profile.

PS: I'm not a Java/Jakarta EE expert, but I guess that the same fix should be applied to the EE migration profile?
