### PR TITLE
Modifies TOMCAT profile

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/EESpecProfile.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/EESpecProfile.java
@@ -25,6 +25,12 @@ import java.util.regex.Pattern;
 public enum EESpecProfile {
 
     TOMCAT("javax([/\\.](annotation(?![/\\.]processing)" +
+            "|el" +
+            "|security[/\\.]auth[/\\.]message" +
+            "|servlet" +
+            "|websocket))"),
+
+    TOMCAT_FULL("javax([/\\.](annotation(?![/\\.]processing)" +
             "|ejb" +
             "|el" +
             "|mail" +

--- a/src/test/java/org/apache/tomcat/jakartaee/EESpecProfileTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/EESpecProfileTest.java
@@ -28,6 +28,56 @@ public class EESpecProfileTest {
         EESpecProfile profile = EESpecProfile.TOMCAT;
 
         assertEquals("jakarta.annotation", profile.convert("javax.annotation"));
+        assertEquals("jakarta.el", profile.convert("javax.el"));
+        assertEquals("jakarta.security.auth.message", profile.convert("javax.security.auth.message"));
+        assertEquals("jakarta.servlet", profile.convert("javax.servlet"));
+        assertEquals("jakarta.websocket", profile.convert("javax.websocket"));
+
+        // not converted EE packages
+        assertEquals("javax.ejb", profile.convert("javax.ejb"));
+        assertEquals("javax.mail", profile.convert("javax.mail"));
+        assertEquals("javax.persistence", profile.convert("javax.persistence"));
+        assertEquals("javax.transaction", profile.convert("javax.transaction"));
+        assertEquals("javax.activation", profile.convert("javax.activation"));
+        assertEquals("javax.batch", profile.convert("javax.batch"));
+        assertEquals("javax.decorator", profile.convert("javax.decorator"));
+        assertEquals("javax.enterprise", profile.convert("javax.enterprise"));
+        assertEquals("javax.faces", profile.convert("javax.faces"));
+        assertEquals("javax.jms", profile.convert("javax.jms"));
+        assertEquals("javax.json", profile.convert("javax.json"));
+        assertEquals("javax.jws", profile.convert("javax.jws"));
+        assertEquals("javax.interceptor", profile.convert("javax.interceptor"));
+        assertEquals("javax.inject", profile.convert("javax.inject"));
+        assertEquals("javax.management.j2ee", profile.convert("javax.management.j2ee"));
+        assertEquals("javax.resource", profile.convert("javax.resource"));
+        assertEquals("javax.security.enterprise", profile.convert("javax.security.enterprise"));
+        assertEquals("javax.security.jacc", profile.convert("javax.security.jacc"));
+        assertEquals("javax.validation", profile.convert("javax.validation"));
+        assertEquals("javax.ws.rs", profile.convert("javax.ws.rs"));
+        assertEquals("javax.xml.bind", profile.convert("javax.xml.bind"));
+        assertEquals("javax.xml.rpc", profile.convert("javax.xml.rpc"));
+        assertEquals("javax.xml.registry", profile.convert("javax.xml.registry"));
+        assertEquals("javax.xml.soap", profile.convert("javax.xml.soap"));
+        assertEquals("javax.xml.ws", profile.convert("javax.xml.ws"));
+
+        // non EE javax packages
+        assertEquals("javax.annotation.processing", profile.convert("javax.annotation.processing"));
+        assertEquals("javax.management", profile.convert("javax.management"));
+        assertEquals("javax.security", profile.convert("javax.security"));
+        assertEquals("javax.security.auth", profile.convert("javax.security.auth"));
+        assertEquals("javax.swing", profile.convert("javax.swing"));
+        assertEquals("javax.transaction.xa", profile.convert("javax.transaction.xa"));
+        assertEquals("javax.xml.stream", profile.convert("javax.xml.stream"));
+        assertEquals("javax.xml.namespace", profile.convert("javax.xml.namespace"));
+        assertEquals("javax.xml.xpath.XPathConstants", profile.convert("javax.xml.xpath.XPathConstants"));
+        assertEquals("javax.xml.XMLConstants", profile.convert("javax.xml.XMLConstants"));
+    }
+
+    @Test
+    public void testProfileTomcatFull() {
+        EESpecProfile profile = EESpecProfile.TOMCAT_FULL;
+
+        assertEquals("jakarta.annotation", profile.convert("javax.annotation"));
         assertEquals("jakarta.ejb", profile.convert("javax.ejb"));
         assertEquals("jakarta.el", profile.convert("javax.el"));
         assertEquals("jakarta.mail", profile.convert("javax.mail"));


### PR DESCRIPTION
Although Tomcat's code references several Jakarta EE APIs, it is distributed with just `annotations-api.jar`, `el-api.jar`, `jaspic-api.jar`, `servlet-api.jar` and `websocket-api.jar`. Therefore all the remaining APIs (e.g. Persistence API) are distributed with the applications.

The current TOMCAT profile causes most applications to fail with a `NoClassDefFoundError`, when the Migration Tool is used as `ClassTransformer` through the `<Loader jakartaConverter="TOMCAT" />` context configuration: the `WebAppClassloader` replaces many references to `javax.*` classes with `jakarta.*` classes, but does not make the inverse transformation, when loading the external API classes.

IMHO the migration tool shouldn't replace `javax.persistence` with `jakarta.persistence` also in other usage context, since this operation requires also the replacement of the JARs shipped with the application.