### PR TITLE
Additional Profile to Migrate Back to JEE8 from Jakarta EE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 *.iml
 *.ipr
 *.iws
+/bin/

--- a/src/main/java/org/apache/tomcat/jakartaee/ClassConverter.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/ClassConverter.java
@@ -26,7 +26,6 @@ import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantUtf8;
@@ -100,10 +99,10 @@ public class ClassConverter implements Converter, ClassFileTransformer {
                         // Jakarta EE specification classes that exist in the container
                         String[] split = newString.split(";|<");
                         for (String current : split) {
-                            int pos = current.indexOf("jakarta/");
+                            int pos = current.indexOf(profile.getTarget() + "/");
                             boolean dotMode = false;
                             if (pos < 0) {
-                                pos = current.indexOf("jakarta.");
+                                pos = current.indexOf(profile.getTarget() + ".");
                                 dotMode = true;
                             }
                             if (pos >= 0) {
@@ -115,14 +114,15 @@ public class ClassConverter implements Converter, ClassFileTransformer {
                                 if (loader.getResource(resourceName) == null) {
                                     if (logger.isLoggable(Level.FINE)) {
                                         logger.log(Level.FINE, sm.getString("classConverter.skipName",
+                                                profile.getSource(),
                                                 current.substring(pos).replace('/','.')));
                                     }
                                     // Cancel the replacement as the replacement does not exist
                                     String originalFragment;
                                     if (dotMode) {
-                                        originalFragment = current.replace("jakarta.", "javax.");
+                                        originalFragment = current.replace(profile.getTarget() + ".", profile.getSource() + ".");
                                     } else {
-                                        originalFragment = current.replace("jakarta/", "javax/");
+                                        originalFragment = current.replace(profile.getTarget() + "/", profile.getSource() + "/");
                                     }
                                     newString = newString.replace(current, originalFragment);
                                 }

--- a/src/main/java/org/apache/tomcat/jakartaee/EESpecProfile.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/EESpecProfile.java
@@ -24,7 +24,8 @@ import java.util.regex.Pattern;
  */
 public enum EESpecProfile {
 
-    TOMCAT("javax([/\\.](annotation(?![/\\.]processing)" +
+    TOMCAT("javax", "jakarta", 
+            "javax([/\\.](annotation(?![/\\.]processing)" +
             "|ejb" +
             "|el" +
             "|mail" +
@@ -34,7 +35,33 @@ public enum EESpecProfile {
             "|transaction(?![/\\.]xa)" +
             "|websocket))"),
 
-    EE("javax([/\\.](activation" +
+    EE("javax", "jakarta", 
+            "javax([/\\.](activation" +
+            "|annotation(?![/\\.]processing)" +
+            "|batch" +
+            "|decorator" +
+            "|ejb" +
+            "|el" +
+            "|enterprise" +
+            "|faces" +
+            "|jms" +
+            "|json" +
+            "|jws" +
+            "|interceptor" +
+            "|inject" +
+            "|mail" +
+            "|management[/\\.]j2ee" +
+            "|persistence" +
+            "|resource" +
+            "|security[/\\.](auth[/\\.]message|enterprise|jacc)" +
+            "|servlet" +
+            "|transaction(?![/\\.]xa)" +
+            "|validation" +
+            "|websocket" +
+            "|ws[/\\.]rs" +
+            "|xml[/\\.](bind|soap|ws)))"),
+    JEE8("jakarta", "javax", 
+            "jakarta([/\\.](activation" +
             "|annotation(?![/\\.]processing)" +
             "|batch" +
             "|decorator" +
@@ -59,14 +86,28 @@ public enum EESpecProfile {
             "|ws[/\\.]rs" +
             "|xml[/\\.](bind|soap|ws)))");
 
+    private String source;
+    private String target;
     private Pattern pattern;
 
-    EESpecProfile(String pattern) {
+    EESpecProfile(String source, String target, String pattern) {
+        this.source = source;
+        this.target = target;
         this.pattern = Pattern.compile(pattern);
     }
 
     public String convert(String name) {
         Matcher m = pattern.matcher(name);
-        return m.replaceAll("jakarta$1");
+        return m.replaceAll(target + "$1");
+    }
+    
+    public String getSource()
+    {
+        return source;
+    }
+    
+    public String getTarget()
+    {
+        return target;
     }
 }

--- a/src/main/resources/org/apache/tomcat/jakartaee/LocalStrings.properties
+++ b/src/main/resources/org/apache/tomcat/jakartaee/LocalStrings.properties
@@ -15,7 +15,7 @@
 
 classConverter.converted=Migrated class [{0}]
 classConverter.noConversion=No conversion necessary for [{0}] 
-classConverter.skipName=Skip conversion of class usage from the javax namespace to [{0}] as it is not accessible to the classloader
+classConverter.skipName=Skip conversion of class usage from the [{0}] namespace to [{1}] as it is not accessible to the classloader
 
 migration.archive.complete=Migration finished for archive [{0}]
 migration.archive.memory=Migration starting for archive [{0}] using in memory copy
@@ -39,6 +39,7 @@ where options includes:\n\
 \    -profile=<profile name>\n\
 \                TOMCAT (default) to convert Java EE APIs provided by Tomcat\n\
 \                EE to convert all Java EE APIs\n\
+\                JEE8 to convert back to old Java EE8 APIs\n\
 \    -zipInMemory\n\
 \                By default zip format archives (.zip, jar, .war, .ear, etc.)\n\
 \                are processed as streams. This is more efficient but is not\n\


### PR DESCRIPTION
We happily used the migration tool to convert our codebase to the new Jakarta EE packages.
As we additionally need to supply a JEE8 compatible version of our software we plan to do a backwards migration as part of our build pipeline.
This pull request extends the migration tool with an additional profile "JEE8" that supports the conversion to the old packages.
The implementation uses the given facilities of pattern matching and extends the profile with the new "source" and "target" fields, that denote the root-package name before migration ("source") and ("afterwards"). 
ClassConverter additionally required replacement of by now hardcoded references to the package-roots.

The given extension of the migration tool will allow a fast adoption of the new Jakarta EE packages in dev and ops without sacrificing the option to provide backward compatibility for clients lagging behind.
