### PR TITLE
Exception in thread "main" java.util.zip.ZipException: Bad CRC checksum for entry

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/Migration.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/Migration.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
@@ -223,6 +224,7 @@ public class Migration {
                 String destName = profile.convert(srcName);
                 RenamableZipArchiveEntry destZipEntry = new RenamableZipArchiveEntry(srcZipEntry);
                 destZipEntry.setName(destName);
+                destZipEntry.setMethod(ZipEntry.DEFLATED);
                 destZipStream.putArchiveEntry(destZipEntry);
                 migrateStream(srcName, srcZipStream, destZipStream);
                 destZipStream.closeArchiveEntry();

--- a/src/main/java/org/apache/tomcat/jakartaee/Migration.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/Migration.java
@@ -224,7 +224,7 @@ public class Migration {
                     continue;
                 }
                 String destName = profile.convert(srcName);
-                RenamableZipArchiveEntry destZipEntry = new RenamableZipArchiveEntry(srcZipEntry);
+                RenamableZipArchiveEntry destZipEntry = new RenamableZipArchiveEntry(srcZipEntry, false);
                 destZipEntry.setName(destName);
                 destZipStream.putRenameZipArchiveEntry(destZipEntry);
                 migrateStream(srcName, srcZipStream, destZipStream);
@@ -254,7 +254,7 @@ public class Migration {
                     continue;
                 }
                 String destName = profile.convert(srcName);
-                RenamableZipArchiveEntry destZipEntry = new RenamableZipArchiveEntry(srcZipEntry);
+                RenamableZipArchiveEntry destZipEntry = new RenamableZipArchiveEntry(srcZipEntry, true);
                 destZipEntry.setName(destName);
                 destZipStream.putArchiveEntry(destZipEntry);
                 migrateStream(srcName, srcZipFile.getInputStream(srcZipEntry), destZipStream);
@@ -323,9 +323,9 @@ public class Migration {
         protected final CRC32 crc = new CRC32();
         protected long size = 0;
         protected boolean needResetCrc;
-        public RenamableZipArchiveEntry(ZipArchiveEntry entry) throws ZipException {
+        public RenamableZipArchiveEntry(ZipArchiveEntry entry, boolean inMemory) throws ZipException {
             super(entry);
-            needResetCrc = entry.getMethod() == ZipEntry.STORED;
+            needResetCrc = !inMemory && entry.getMethod() == ZipEntry.STORED;
         }
 
         @Override


### PR DESCRIPTION
See #29 

The problem is that common-compression has CRC checks when the closeArchiveEntry method is executed, when the method of the Entry is not DEFLATED and the SeekableByteChannel is not used.
However, because we have some information modification at the time of Converter, the CRC value calculated after the modification must not be equal to the value of the CRC in the original Entry.



The original Entry information is retained.
https://github.com/apache/tomcat-jakartaee-migration/blob/34d7c72aa0eea3d403b287b10e92cdcead0676c7/src/main/java/org/apache/tomcat/jakartaee/Migration.java#L319-L329

There is another way to recalculate the CRC, but I don't feel it makes much sense and there is a performance overhead.
