### PR TITLE
fixes #32 check if file name ends with manifest name

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/ManifestConverter.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/ManifestConverter.java
@@ -39,7 +39,7 @@ public class ManifestConverter implements Converter {
 
     @Override
     public boolean accepts(String filename) {
-        if (JarFile.MANIFEST_NAME.equals(filename)) {
+        if (filename.endsWith(JarFile.MANIFEST_NAME)) {
             return true;
         }
 

--- a/src/test/java/org/apache/tomcat/jakartaee/ManifestConverterTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/ManifestConverterTest.java
@@ -1,0 +1,16 @@
+package org.apache.tomcat.jakartaee;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ManifestConverterTest {
+
+	@Test
+    public void testAccepts() {
+		ManifestConverter converter = new ManifestConverter();
+
+        assertTrue(converter.accepts("META-INF/MANIFEST.MF"));
+        assertTrue(converter.accepts("WEB-INF/bundles/com.example.bundle/META-INF/MANIFEST.MF"));
+    }
+}

--- a/src/test/java/org/apache/tomcat/jakartaee/ManifestConverterTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/ManifestConverterTest.java
@@ -6,9 +6,9 @@ import org.junit.Test;
 
 public class ManifestConverterTest {
 
-	@Test
+    @Test
     public void testAccepts() {
-		ManifestConverter converter = new ManifestConverter();
+        ManifestConverter converter = new ManifestConverter();
 
         assertTrue(converter.accepts("META-INF/MANIFEST.MF"));
         assertTrue(converter.accepts("WEB-INF/bundles/com.example.bundle/META-INF/MANIFEST.MF"));


### PR DESCRIPTION
Check if the file name ends with the manifest name so that exploded archives with a war deployment are also migrated.