### PR TITLE
Exclude Findbugs JSR-305 annotation packages and classes

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/EESpecProfiles.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/EESpecProfiles.java
@@ -17,15 +17,15 @@
 
 package org.apache.tomcat.jakartaee;
 
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 /**
  * Specification profile defining the replacements performed.
  */
 public enum EESpecProfiles implements EESpecProfile {
-
     TOMCAT("javax", "jakarta",
-            "javax([/\\.](annotation(?![/\\.]processing)" +
+            "javax([/\\.](annotation[/\\.](" + Patterns.ANNOTATION_CLASSES + ")" +
                     "|ejb" +
                     "|el" +
                     "|mail" +
@@ -37,7 +37,7 @@ public enum EESpecProfiles implements EESpecProfile {
 
     EE("javax", "jakarta",
             "javax([/\\.](activation" +
-                    "|annotation(?![/\\.]processing)" +
+                    "|annotation[/\\.](" + Patterns.ANNOTATION_CLASSES + ")" +
                     "|batch" +
                     "|decorator" +
                     "|ejb" +
@@ -60,9 +60,10 @@ public enum EESpecProfiles implements EESpecProfile {
                     "|websocket" +
                     "|ws[/\\.]rs" +
                     "|xml[/\\.](bind|soap|ws)))"),
+
     JEE8("jakarta", "javax",
             "jakarta([/\\.](activation" +
-                    "|annotation(?![/\\.]processing)" +
+                    "|annotation[/\\.](" + Patterns.ANNOTATION_CLASSES + ")" +
                     "|batch" +
                     "|decorator" +
                     "|ejb" +
@@ -85,6 +86,31 @@ public enum EESpecProfiles implements EESpecProfile {
                     "|websocket" +
                     "|ws[/\\.]rs" +
                     "|xml[/\\.](bind|soap|ws)))");
+
+    private static final class Patterns {
+        /*
+         * Prefixes of classes provided by tomcat-annotations-api 8.5. Nullable and Notnull are present in later
+         * versions but the Findbugs JSR-305 implementation also has checkers that can't be satisfied by other
+         * implementations, so we avoid migrating those.
+         */
+        static final String ANNOTATION_CLASSES = String.join("|",
+                Arrays.asList(
+                        "Generated",
+                        "ManagedBean",
+                        "PostConstruct",
+                        "PreDestroy",
+                        "Priority",
+                        "Resource",
+                        "Resources",
+                        "security/DeclareRoles",
+                        "security/DenyAll",
+                        "security/PermitAll",
+                        "security/RolesAllowed",
+                        "security/RunAs",
+                        "sql/DataSourceDefinition"
+                ));
+    }
+
     private String source;
     private String target;
     private Pattern pattern;

--- a/src/main/java/org/apache/tomcat/jakartaee/ManifestConverter.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/ManifestConverter.java
@@ -63,8 +63,11 @@ public class ManifestConverter implements Converter {
 
         if (srcManifest.equals(destManifest)) {
             IOUtils.writeChunked(srcBytes, dest);
+            logger.log(Level.FINEST, sm.getString("manifestConverter.noConversion", path));
         } else {
             destManifest.write(dest);
+            String key = converted ? "manifestConverter.converted" : "manifestConverter.updated";
+            logger.log(Level.FINE, sm.getString(key, path));
         }
 
         return converted;
@@ -79,7 +82,7 @@ public class ManifestConverter implements Converter {
             if (isCryptoSignatureEntry(entry.getValue())) {
                 String entryName = entry.getKey();
                 signatureEntries.add(entryName);
-                logger.log(Level.FINE, sm.getString("migration.removeSignature", entryName));
+                logger.log(Level.FINE, sm.getString("manifestConverter.removeSignature", entryName));
             }
         }
 
@@ -114,6 +117,7 @@ public class ManifestConverter implements Converter {
         if (attributes.containsKey(Attributes.Name.IMPLEMENTATION_VERSION)) {
             String newValue = attributes.get(Attributes.Name.IMPLEMENTATION_VERSION) + "-" + Info.getVersion();
             attributes.put(Attributes.Name.IMPLEMENTATION_VERSION, newValue);
+            logger.log(Level.FINE, sm.getString("manifestConverter.updatedVersion", newValue));
             // Purposefully avoid setting result
         }
         // Update package names in values

--- a/src/main/java/org/apache/tomcat/jakartaee/Migration.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/Migration.java
@@ -201,6 +201,7 @@ public class Migration {
                 throw new IOException(sm.getString("migration.mkdirError", parentDestination.getAbsolutePath()));
             }
         }
+        state = State.COMPLETE;
         logger.log(Level.INFO, sm.getString("migration.done",
                 TimeUnit.MILLISECONDS.convert(System.nanoTime() - t1, TimeUnit.NANOSECONDS)));
     }

--- a/src/main/resources/org/apache/tomcat/jakartaee/LocalStrings.properties
+++ b/src/main/resources/org/apache/tomcat/jakartaee/LocalStrings.properties
@@ -26,8 +26,7 @@ migration.alreadyRunning=Migration is already running
 migration.done=Migration completed successfully in [{0}] milliseconds
 migration.error=Error performing migration
 migration.execute=Performing migration from source [{0}] to destination [{1}] with Jakarta EE specification profile [{2}]
-migration.mkdirError=Error creating destination directory [{0}]
-migration.removeSignature=Remove cryptographic signature for [{0}]
+migration.mkdirError=Error creating destination directory [{0}]a
 migration.skip=Migration skipped for archive [{0}] because it is excluded (the archive was copied unchanged)
 migration.skipSignatureFile=Drop cryptographic signature file [{0}]
 migration.usage=Usage: Migration [options] <source> <destination>\n\
@@ -57,3 +56,9 @@ passThroughConverter.noConversion=No conversion necessary for [{0}]
 
 textConverter.converted=Migrated text file [{0}]
 textConverter.noConversion=No conversion necessary for [{0}]
+
+manifestConverter.converted=Migrated manifest file [{0}]
+manifestConverter.updated=Updated manifest file [{0}]
+manifestConverter.updatedVersion=Updated manifest version to [{0}]
+manifestConverter.removeSignature=Remove cryptographic signature for [{0}]
+manifestConverter.noConversion=No manifest conversion necessary for [{0}]

--- a/src/test/java/org/apache/tomcat/jakartaee/EESpecProfileTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/EESpecProfileTest.java
@@ -27,7 +27,6 @@ public class EESpecProfileTest {
     public void testProfileTomcat() {
         EESpecProfile profile = EESpecProfiles.TOMCAT;
 
-        assertEquals("jakarta.annotation", profile.convert("javax.annotation"));
         assertEquals("jakarta.ejb", profile.convert("javax.ejb"));
         assertEquals("jakarta.el", profile.convert("javax.el"));
         assertEquals("jakarta.mail", profile.convert("javax.mail"));
@@ -61,7 +60,7 @@ public class EESpecProfileTest {
         assertEquals("javax.xml.ws", profile.convert("javax.xml.ws"));
 
         // non EE javax packages
-        assertEquals("javax.annotation.processing", profile.convert("javax.annotation.processing"));
+        assertEquals("javax.annotation", profile.convert("javax.annotation"));
         assertEquals("javax.management", profile.convert("javax.management"));
         assertEquals("javax.security", profile.convert("javax.security"));
         assertEquals("javax.security.auth", profile.convert("javax.security.auth"));
@@ -71,14 +70,22 @@ public class EESpecProfileTest {
         assertEquals("javax.xml.namespace", profile.convert("javax.xml.namespace"));
         assertEquals("javax.xml.xpath.XPathConstants", profile.convert("javax.xml.xpath.XPathConstants"));
         assertEquals("javax.xml.XMLConstants", profile.convert("javax.xml.XMLConstants"));
+
+        // Findbugs JSR-305 packages and classes
+        assertEquals("javax.annotation.concurrent", profile.convert("javax.annotation.concurrent"));
+        assertEquals("javax.annotation.meta", profile.convert("javax.annotation.meta"));
+        assertEquals("javax.annotation.PropertyKey", profile.convert("javax.annotation.PropertyKey"));
+
+        // Annotation classes that overlap between earlier and later annotations implementations
+        assertEquals("javax.annotation.Nonnull", profile.convert("javax.annotation.Nonnull"));
+        assertEquals("javax.annotation.Nullable", profile.convert("javax.annotation.Nullable"));
     }
 
     @Test
     public void testProfileEE() {
         EESpecProfile profile = EESpecProfiles.EE;
 
-        assertEquals("jakarta.activation", profile.convert("javax.activation"));
-        assertEquals("jakarta.annotation", profile.convert("javax.annotation"));
+        assertEquals("jakarta.activation.Generated", profile.convert("javax.activation.Generated"));
         assertEquals("jakarta.batch", profile.convert("javax.batch"));
         assertEquals("jakarta.decorator", profile.convert("javax.decorator"));
         assertEquals("jakarta.ejb", profile.convert("javax.ejb"));
@@ -119,6 +126,5 @@ public class EESpecProfileTest {
         assertEquals("javax.xml.rpc", profile.convert("javax.xml.rpc"));
         assertEquals("javax.xml.xpath.XPathConstants", profile.convert("javax.xml.xpath.XPathConstants"));
         assertEquals("javax.xml.XMLConstants", profile.convert("javax.xml.XMLConstants"));
-
     }
 }

--- a/src/test/java/org/apache/tomcat/jakartaee/MigrationTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/MigrationTest.java
@@ -162,6 +162,8 @@ public class MigrationTest {
             assertNotEquals("Implementation-Version manifest attribute not changed", "1.2.3", implementationVersion);
             assertTrue("Implementation-Version manifest attribute doesn't match the expected pattern", implementationVersion.matches("1\\.2\\.3-migrated-[\\d\\.]+.*"));
         }
+
+        assertTrue("hasConverted should be true", migration.hasConverted());
     }
 
     @Test


### PR DESCRIPTION
On deeper investigation, it turns out the problems I had with `javax.annotation` when testing https://github.com/apache/tomcat-jakartaee-migration/pull/36 were all Findbugs JSR-305 annotation related. 

This adds excludes for the classes/packages provided by this library to avoid heavy handed translation of `javax.annotation` references.

The one special case where `jakarta.annotations` does provide them is Nullable/Nonnull, see the tests for an explanation.

Here's Guava before:
```
Performing migration from source [/Users/dannyt/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/31.1-jre/60458f877d055d0c9114d9e1a2efb737b4bc282c/guava-31.1-jre.jar] to destination [/Users/dannyt/Downloads/guava.jar] with Jakarta EE specification profile [TOMCAT]
Migration starting for archive [guava-31.1-jre.jar] using streaming
Migrated text file [META-INF/maven/com.google.guava/guava/pom.xml]
Migrated class [com.google.common.base.Absent.class]
Migrated class [com.google.common.base.AbstractIterator.class]
Migrated class [com.google.common.base.CaseFormat$StringConverter.class]
Migrated class [com.google.common.base.Converter$1$1.class]
Migrated class [com.google.common.base.Converter$ConverterComposition.class]
... lots of classes ...
Migrated class [com.google.common.util.concurrent.Monitor$Guard.class]
Migrated class [com.google.common.util.concurrent.Monitor.class]
Migrated class [com.google.common.util.concurrent.NullnessCasts.class]
Migrated class [com.google.common.util.concurrent.OverflowAvoidingLockSupport.class]
Migrated class [com.google.common.util.concurrent.ParametricNullness.class]
Migrated class [com.google.common.util.concurrent.Platform.class]
Migrated class [com.google.common.util.concurrent.RateLimiter.class]
Migrated class [com.google.common.util.concurrent.SequentialExecutor$QueueWorker.class]
Migrated class [com.google.common.util.concurrent.SimpleTimeLimiter$1.class]
Migrated class [com.google.common.util.concurrent.ThreadFactoryBuilder.class]
Migrated class [com.google.common.util.concurrent.TimeoutFuture$Fire.class]
Migrated class [com.google.common.util.concurrent.TimeoutFuture.class]
Migrated class [com.google.common.util.concurrent.TrustedListenableFutureTask.class]
Migrated class [com.google.common.util.concurrent.UncheckedExecutionException.class]
Migrated class [com.google.common.util.concurrent.UncheckedTimeoutException.class]
Migrated class [com.google.common.util.concurrent.package-info.class]
Migrated class [com.google.common.xml.ElementTypesAreNonnullByDefault.class]
Migrated class [com.google.common.xml.ParametricNullness.class]
Migrated class [com.google.common.xml.package-info.class]
Migration finished for archive [guava-31.1-jre.jar]
Migration completed successfully in [1,171] milliseconds
```

And after:
```
Performing migration from source [/Users/dannyt/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/31.1-jre/60458f877d055d0c9114d9e1a2efb737b4bc282c/guava-31.1-jre.jar] to destination [/Users/dannyt/Downloads/guava.jar] with Jakarta EE specification profile [TOMCAT]
Migration starting for archive [guava-31.1-jre.jar] using streaming
Migrated text file [META-INF/maven/com.google.guava/guava/pom.xml]
Migration finished for archive [guava-31.1-jre.jar]
Migration completed successfully in [528] milliseconds
```