### PR TITLE
Avoid bcel thread safety issue

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/ClassConverter.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/ClassConverter.java
@@ -31,12 +31,18 @@ import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantUtf8;
 import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.util.SyntheticRepository;
 import org.apache.commons.io.IOUtils;
 
 /**
  * Class converter and transformer.
  */
 public class ClassConverter implements Converter, ClassFileTransformer {
+
+    static {
+        // Avoid ConcurrentModificationException from SyntheticRepository when migrations are run concurrently
+        SyntheticRepository.getInstance();
+    }
 
     private static final Logger logger = Logger.getLogger(ClassConverter.class.getCanonicalName());
     private static final StringManager sm = StringManager.getManager(ClassConverter.class);


### PR DESCRIPTION
Allow `ClassConverter` to be used safely in parallel by avoiding `ConcurrentModificationException` from `SyntheticRepository` for the default `getInstance`:
```
java.util.ConcurrentModificationException: (No message provided)
	at java.util.HashMap.computeIfAbsent(HashMap.java:1221)	
	at org.apache.bcel.util.SyntheticRepository.getInstance(SyntheticRepository.java:44)	
	at org.apache.bcel.util.SyntheticRepository.getInstance(SyntheticRepository.java:40)	
	at org.apache.bcel.classfile.JavaClass.<init>(JavaClass.java:139)	
	at org.apache.bcel.classfile.ClassParser.parse(ClassParser.java:180)	
	at org.apache.tomcat.jakartaee.ClassConverter.convertInternal(ClassConverter.java:86)	
	at org.apache.tomcat.jakartaee.ClassConverter.convert(ClassConverter.java:63)	
	at org.apache.tomcat.jakartaee.Migration.migrateStream(Migration.java:346)	
	at org.apache.tomcat.jakartaee.Migration.migrateArchiveStreaming(Migration.java:277)	
	at org.apache.tomcat.jakartaee.Migration.migrateStream(Migration.java:340)	
	at org.apache.tomcat.jakartaee.Migration.migrateFile(Migration.java:233)	
	at org.apache.tomcat.jakartaee.Migration.execute(Migration.java:199)	
	at org.apache.tomcat.jakartaee.Migration$execute$3.call(Unknown Source)
```
