### PR TITLE
Migrate SPI files in directories by renaming them to the jakartaee pr…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Tomcat Migration Tool for Jakarta EE - Changelog
 
+## 1.0.7
+
+- When converting directories, rename files according to the chosen profile. (fschumacher)
+
 ## 1.0.6
 
 - Fix handling of javax.annotation package in 1.0.5. PR [#40](https://github.com/apache/tomcat-jakartaee-migration/pull/40) provided by Danny Thomas (remm)

--- a/src/main/java/org/apache/tomcat/jakartaee/Migration.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/Migration.java
@@ -252,7 +252,7 @@ public class Migration {
         String[] files = src.list();
         for (String file : files) {
             File srcFile = new File(src, file);
-            File destFile = new File(dest, file);
+            File destFile = new File(dest, profile.convert(file));
             if (srcFile.isDirectory()) {
                 if ((destFile.exists() && destFile.isDirectory()) || destFile.mkdir()) {
                     migrateDirectory(srcFile, destFile);
@@ -264,7 +264,6 @@ public class Migration {
             }
         }
     }
-
 
     private void migrateFile(File src, File dest) throws IOException {
         boolean inplace = src.equals(dest);

--- a/src/test/java/org/apache/tomcat/jakartaee/MigrationTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/MigrationTest.java
@@ -139,6 +139,39 @@ public class MigrationTest {
         String migratedSource = FileUtils.readFileToString(migratedFile, StandardCharsets.UTF_8);
         assertFalse("Imports not migrated", migratedSource.contains("import javax.servlet"));
         assertTrue("Migrated imports not found", migratedSource.contains("import jakarta.servlet"));
+
+        File migratedSpiFile = new File("target/test-classes/migration/javax.enterprise.inject.spi.Extension");
+        assertTrue("SPI file has not been migrated by renaming", migratedSpiFile.exists());
+
+        String migratedSpiSource = FileUtils.readFileToString(migratedSpiFile, StandardCharsets.UTF_8);
+        assertTrue("SPI file copied with content", migratedSpiSource.contains("some.class.Reference"));
+    }
+
+    @Test
+    public void testMigrateDirectoryWithEeProfile() throws Exception {
+        File sourceDirectory = new File("src/test/resources");
+        File destinationDirectory = new File("target/test-classes/migration-ee");
+
+        Migration migration = new Migration();
+        migration.setEESpecProfile(EESpecProfiles.EE);
+        migration.setSource(sourceDirectory);
+        migration.setDestination(destinationDirectory);
+        migration.execute();
+
+        assertTrue("Destination directory not found", destinationDirectory.exists());
+
+        File migratedFile = new File(destinationDirectory, "HelloServlet.java");
+        assertTrue("Migrated file not found", migratedFile.exists());
+
+        String migratedSource = FileUtils.readFileToString(migratedFile, StandardCharsets.UTF_8);
+        assertFalse("Imports not migrated", migratedSource.contains("import javax.servlet"));
+        assertTrue("Migrated imports not found", migratedSource.contains("import jakarta.servlet"));
+
+        File migratedSpiFile = new File(destinationDirectory, "jakarta.enterprise.inject.spi.Extension");
+        assertTrue("SPI file migrated by renaming", migratedSpiFile.exists());
+
+        String migratedSpiSource = FileUtils.readFileToString(migratedSpiFile, StandardCharsets.UTF_8);
+        assertTrue("SPI file copied with content", migratedSpiSource.contains("some.class.Reference"));
     }
 
     @Test

--- a/src/test/java/org/apache/tomcat/jakartaee/MigrationTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/MigrationTest.java
@@ -144,7 +144,7 @@ public class MigrationTest {
         assertTrue("SPI file has not been migrated by renaming", migratedSpiFile.exists());
 
         String migratedSpiSource = FileUtils.readFileToString(migratedSpiFile, StandardCharsets.UTF_8);
-        assertTrue("SPI file copied with content", migratedSpiSource.contains("some.class.Reference"));
+        assertTrue("SPI file not copied with content", migratedSpiSource.contains("some.class.Reference"));
     }
 
     @Test
@@ -168,10 +168,10 @@ public class MigrationTest {
         assertTrue("Migrated imports not found", migratedSource.contains("import jakarta.servlet"));
 
         File migratedSpiFile = new File(destinationDirectory, "jakarta.enterprise.inject.spi.Extension");
-        assertTrue("SPI file migrated by renaming", migratedSpiFile.exists());
+        assertTrue("SPI file not migrated by renaming", migratedSpiFile.exists());
 
         String migratedSpiSource = FileUtils.readFileToString(migratedSpiFile, StandardCharsets.UTF_8);
-        assertTrue("SPI file copied with content", migratedSpiSource.contains("some.class.Reference"));
+        assertTrue("SPI file not copied with content", migratedSpiSource.contains("some.class.Reference"));
     }
 
     @Test

--- a/src/test/resources/javax.enterprise.inject.spi.Extension
+++ b/src/test/resources/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+some.class.Reference


### PR DESCRIPTION
…efix

We already rename files in JAR files, so directory handling should follow here. A more correct way to handle this, would probably be to restrict the renaming to files, that are found in META-INF/services directories, only.