### PR TITLE
servlet profile added, covers javax.servlet only

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/EESpecProfiles.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/EESpecProfiles.java
@@ -26,6 +26,12 @@ import java.util.regex.Pattern;
 public enum EESpecProfiles implements EESpecProfile {
 
     /**
+     * Specification profile matching the Jakarta Servlet API only.
+     */
+    SERVLET("javax", "jakarta",
+          "javax([/\\.](servlet))"),
+
+    /**
      * Specification profile matching the packages provided with Tomcat.
      */
     TOMCAT("javax", "jakarta",

--- a/src/main/resources/org/apache/tomcat/jakartaee/LocalStrings.properties
+++ b/src/main/resources/org/apache/tomcat/jakartaee/LocalStrings.properties
@@ -40,6 +40,7 @@ where options includes:\n\
 \    -profile=<profile name>\n\
 \                TOMCAT (default) to convert Java EE APIs provided by Tomcat\n\
 \                EE to convert all Java EE APIs\n\
+\                SERVLET to convert the Jakarta Servlet API only\n\
 \                JEE8 to convert back to old Java EE8 APIs. Note that the\n\
 \                    resulting classes will not work if the classes to be\n\
 \                    migrated use any APIs added in Jakarta EE 10 onwards.\n\

--- a/src/test/java/org/apache/tomcat/jakartaee/EESpecProfileTest.java
+++ b/src/test/java/org/apache/tomcat/jakartaee/EESpecProfileTest.java
@@ -24,6 +24,66 @@ import static org.junit.Assert.*;
 public class EESpecProfileTest {
 
     @Test
+    public void testProfileServlet() {
+        EESpecProfile profile = EESpecProfiles.SERVLET;
+
+        assertEquals("javax.annotation.PostConstruct", profile.convert("javax.annotation.PostConstruct"));
+        assertEquals("javax.annotation.security.DeclareRoles", profile.convert("javax.annotation.security.DeclareRoles"));
+        assertEquals("javax.ejb", profile.convert("javax.ejb"));
+        assertEquals("javax.el", profile.convert("javax.el"));
+        assertEquals("javax.mail", profile.convert("javax.mail"));
+        assertEquals("javax.persistence", profile.convert("javax.persistence"));
+        assertEquals("javax.security.auth.message", profile.convert("javax.security.auth.message"));
+        assertEquals("jakarta.servlet", profile.convert("javax.servlet"));
+        assertEquals("javax.transaction", profile.convert("javax.transaction"));
+        assertEquals("javax.websocket", profile.convert("javax.websocket"));
+
+        // not converted EE packages
+        assertEquals("javax.activation", profile.convert("javax.activation"));
+        assertEquals("javax.batch", profile.convert("javax.batch"));
+        assertEquals("javax.decorator", profile.convert("javax.decorator"));
+        assertEquals("javax.enterprise", profile.convert("javax.enterprise"));
+        assertEquals("javax.faces", profile.convert("javax.faces"));
+        assertEquals("javax.jms", profile.convert("javax.jms"));
+        assertEquals("javax.json", profile.convert("javax.json"));
+        assertEquals("javax.jws", profile.convert("javax.jws"));
+        assertEquals("javax.interceptor", profile.convert("javax.interceptor"));
+        assertEquals("javax.inject", profile.convert("javax.inject"));
+        assertEquals("javax.management.j2ee", profile.convert("javax.management.j2ee"));
+        assertEquals("javax.resource", profile.convert("javax.resource"));
+        assertEquals("javax.security.enterprise", profile.convert("javax.security.enterprise"));
+        assertEquals("javax.security.jacc", profile.convert("javax.security.jacc"));
+        assertEquals("javax.validation", profile.convert("javax.validation"));
+        assertEquals("javax.ws.rs", profile.convert("javax.ws.rs"));
+        assertEquals("javax.xml.bind", profile.convert("javax.xml.bind"));
+        assertEquals("javax.xml.rpc", profile.convert("javax.xml.rpc"));
+        assertEquals("javax.xml.registry", profile.convert("javax.xml.registry"));
+        assertEquals("javax.xml.soap", profile.convert("javax.xml.soap"));
+        assertEquals("javax.xml.ws", profile.convert("javax.xml.ws"));
+
+        // non EE javax packages
+        assertEquals("javax.annotation", profile.convert("javax.annotation"));
+        assertEquals("javax.management", profile.convert("javax.management"));
+        assertEquals("javax.security", profile.convert("javax.security"));
+        assertEquals("javax.security.auth", profile.convert("javax.security.auth"));
+        assertEquals("javax.swing", profile.convert("javax.swing"));
+        assertEquals("javax.transaction.xa", profile.convert("javax.transaction.xa"));
+        assertEquals("javax.xml.stream", profile.convert("javax.xml.stream"));
+        assertEquals("javax.xml.namespace", profile.convert("javax.xml.namespace"));
+        assertEquals("javax.xml.xpath.XPathConstants", profile.convert("javax.xml.xpath.XPathConstants"));
+        assertEquals("javax.xml.XMLConstants", profile.convert("javax.xml.XMLConstants"));
+
+        // Findbugs JSR-305 packages and classes
+        assertEquals("javax.annotation.concurrent", profile.convert("javax.annotation.concurrent"));
+        assertEquals("javax.annotation.meta", profile.convert("javax.annotation.meta"));
+        assertEquals("javax.annotation.PropertyKey", profile.convert("javax.annotation.PropertyKey"));
+
+        // Annotation classes that overlap between earlier and later annotations implementations
+        assertEquals("javax.annotation.Nonnull", profile.convert("javax.annotation.Nonnull"));
+        assertEquals("javax.annotation.Nullable", profile.convert("javax.annotation.Nullable"));
+    }
+
+    @Test
     public void testProfileTomcat() {
         EESpecProfile profile = EESpecProfiles.TOMCAT;
 


### PR DESCRIPTION
The profile TOMCAT does not work for me. For instance it converts javax.mail, which is provided by my web application, not Tomcat. So it is not affected by the upgrade of Tomcat 9 -> 10.1 at all. Migrating javax.mail breaks my application.

Of course I will upgrade javax.mail to jakarta.mail (and other packages) as well. But I'd like to do this step by step.