### PR TITLE
javax2jakarta has been included in Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ the same type as the source.
 >
 > A warning will be logged for each JAR file where the signature has been removed.
 
-This tool is also available on Debian and Ubuntu systems by installing the
-[tomcat-jakartaee-migration](https://tracker.debian.org/tomcat-jakartaee-migration)
-package and invoking the `javax2jakarta` command.
+This tool is also available on [Debian, Ubuntu](https://tracker.debian.org/tomcat-jakartaee-migration) and [Fedora](https://packages.fedoraproject.org/pkgs/tomcat-jakartaee-migration/tomcat-jakartaee-migration/) systems by installing the
+*tomcat-jakartaee-migration* package and invoking the `javax2jakarta` command.
 
 ## Ant task
 


### PR DESCRIPTION
Fedora 40 commit: https://src.fedoraproject.org/rpms/tomcat-jakartaee-migration/c/3e275864cfe33325f99ad6ca3fc2a82e5d9dab7b?branch=f40

Fedora rawhide commit: https://src.fedoraproject.org/rpms/tomcat-jakartaee-migration/c/81751fd16508e5b4592a795a20e58e3053e11bf7?branch=rawhide