### PR TITLE
matchExcludesAgainstPathName not match with absolutePath and no rewrite file if not changed

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/ManifestConverter.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/ManifestConverter.java
@@ -75,6 +75,7 @@ public class ManifestConverter implements Converter {
             destManifest.write(dest);
             String key = converted ? "manifestConverter.converted" : "manifestConverter.updated";
             logger.log(Level.FINE, sm.getString(key, path));
+            converted = true;
         }
 
         return converted;

--- a/src/main/java/org/apache/tomcat/jakartaee/Migration.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/Migration.java
@@ -283,13 +283,13 @@ public class Migration {
         if (!inplace) {
             try (InputStream is = new FileInputStream(src);
                     OutputStream os = new FileOutputStream(dest)) {
-                migrateStream(src.getName(), is, os);
+                migrateStream(src.getAbsolutePath(), is, os);
             }
         } else {
             ByteArrayOutputStream buffer = new ByteArrayOutputStream((int) (src.length() * 1.05));
 
             try (InputStream is = new FileInputStream(src)) {
-                migrateStream(src.getName(), is, buffer);
+                migrateStream(src.getAbsolutePath(), is, buffer);
             }
 
             try (OutputStream os = new FileOutputStream(dest)) {


### PR DESCRIPTION
The -exclude parameter with the -matchExcludesAgainstPathName parameter only works for file names and not on the directory. When calling isExcluded with the matchExcludesAgainstPathName parameter The following code is executed:

File f = new File(name);
String filename = f.getName();
if (matchExcludesAgainstPathName && GlobMatcher.matchName(excludes, name, true)) { return true;
}

The value of name is equal to the file name and never to the full path, matching with a directory cannot be done.

example: -matchExcludesAgainstPathName -exclude=*.git*