### PR TITLE
use same same directory as source and destination:

### DIFF
--- a/src/main/java/org/apache/tomcat/jakartaee/ManifestConverter.java
+++ b/src/main/java/org/apache/tomcat/jakartaee/ManifestConverter.java
@@ -75,6 +75,7 @@ public class ManifestConverter implements Converter {
             destManifest.write(dest);
             String key = converted ? "manifestConverter.converted" : "manifestConverter.updated";
             logger.log(Level.FINE, sm.getString(key, path));
+            converted = true;
         }
 
         return converted;


### PR DESCRIPTION
For example use directory with non-writable files, example git repository :

java -jar jakartaee-migration-1.0.8-shaded.jar C:\work\

jakartaee-migration read and write all files including those that have no been modified. and

We can come across this kind of problem:
Exception in thread "main" java.io.FileNotFoundException: C:\work\.git\objects\01\88c5faf5f495d7475de1b6f9a9760022cb97de (Access denied)

Conclusion, jakartaee-migration-1.0.8-shaded.jar open and write 88c5faf5f495d7475de1b6f9a9760022cb97de  file but 
It reads and writes a file blocked by the OS.
It should only write the files that were actually modified.